### PR TITLE
`ignoreUpdates()` and `stopUpdatesWatch()` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - `submit()` and `validate()` methods are now exposed directly by `useForm()`;
+- `ignoreUpdates()` and `stopUpdatesWatch()` methods are now exposed by `useForm()` and in `VvForm` component default slot scope;
 - `VvForm` component `tag` prop;
 - support for zod async refines with [`safeParseAsync()`](https://zod.dev/?id=safeparseasync).
 
 ### Changed
 
+- `VvForm` prop `updateThrottle` is not used anymore, use `updateThrottle` option of `useForm()` instead;
 - `submit()` and `validate()` methods of `VvForm` component now return a `Promise` of `boolean` instead of `boolean` directly.
 
 ## [0.0.14] - 2023-08-03

--- a/src/VvFormField.ts
+++ b/src/VvFormField.ts
@@ -38,7 +38,7 @@ export const defineFormField = <Schema extends FormSchema>(
 ) => {
 	// define component
 	return defineComponent({
-		name: 'FieldComponent',
+		name: 'VvFormField',
 		props: {
 			type: {
 				type: String as PropType<`${FormFieldType}`>,

--- a/src/VvFormTemplate.ts
+++ b/src/VvFormTemplate.ts
@@ -20,6 +20,7 @@ export const defineFormTemplate = <Schema extends FormSchema>(
 	VvFormField: Component,
 ) => {
 	const VvFormTemplate = defineComponent({
+		name: 'VvFormTemplate',
 		props: {
 			schema: {
 				type: [Array, Function] as PropType<FormTemplate<Schema>>,

--- a/src/VvFormWrapper.ts
+++ b/src/VvFormWrapper.ts
@@ -24,7 +24,7 @@ export const defineFormWrapper = <Schema extends FormSchema>(
 	wrapperProvideKey: InjectionKey<InjectedFormWrapperData<Schema>>,
 ) => {
 	const VvFormWrapper = defineComponent({
-		name: 'WrapperComponent',
+		name: 'VvFormWrapper',
 		props: {
 			name: {
 				type: String,

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -26,4 +26,6 @@ export enum FormStatus {
 	invalid = 'invalid',
 	valid = 'valid',
 	submitting = 'submitting',
+	updated = 'updated',
+	unknown = 'unknown',
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,12 +48,16 @@ const _formFactory = <Schema extends FormSchema>(
 		options,
 	)
 	const VvFormTemplate = defineFormTemplate(formInjectionKey, VvFormField)
-	const { VvForm, errors, status, formData, validate, submit } = defineForm(
-		schema,
-		formInjectionKey,
-		options,
-		VvFormTemplate,
-	)
+	const {
+		VvForm,
+		errors,
+		status,
+		formData,
+		validate,
+		submit,
+		ignoreUpdates,
+		stopUpdatesWatch,
+	} = defineForm(schema, formInjectionKey, options, VvFormTemplate)
 
 	return {
 		VvForm,
@@ -68,6 +72,8 @@ const _formFactory = <Schema extends FormSchema>(
 		formData,
 		validate,
 		submit,
+		ignoreUpdates,
+		stopUpdatesWatch,
 	}
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
-import { type Component, type DeepReadonly, type Ref } from 'vue'
+import type { Component, DeepReadonly, Ref, WatchStopHandle } from 'vue'
 import type { z, AnyZodObject, ZodEffects, inferFormattedError } from 'zod'
+import type { IgnoredUpdater } from '@vueuse/core'
 import type { FormFieldType, FormStatus } from './enums'
 
 export type FormSchema =
@@ -47,6 +48,8 @@ export type InjectedFormData<Schema extends FormSchema> = {
 	>
 	submit: () => Promise<boolean>
 	validate: () => Promise<boolean>
+	ignoreUpdates: IgnoredUpdater
+	stopUpdatesWatch: WatchStopHandle
 	status: Readonly<Ref<FormStatus | undefined>>
 	invalid: Readonly<Ref<boolean>>
 }

--- a/test-playwright/VvForm.vue
+++ b/test-playwright/VvForm.vue
@@ -3,7 +3,9 @@
 	import { z } from 'zod'
 	import { ref, type Ref } from 'vue'
 
-	defineProps(['continuosValidation'])
+	defineProps({
+		continuosValidation: Boolean,
+	})
 	defineEmits(['submit', 'invalid', 'valid'])
 
 	const zodSchema = z.object({
@@ -25,12 +27,12 @@
 
 <template>
 	<VvForm
+		ref="formEl"
 		v-bind="{ continuosValidation }"
 		v-model="model"
 		@submit="$emit('submit')"
 		@invalid="$emit('invalid')"
 		@valid="$emit('valid')"
-		ref="formEl"
 	>
 		<VvFormField name="firstname" type="text" label="firstname" />
 		<VvFormField name="surname" type="text" label="surname" />

--- a/test-playwright/VvFormField.vue
+++ b/test-playwright/VvFormField.vue
@@ -41,13 +41,18 @@
 
 <template>
 	<VvForm ref="formEl" v-model="model">
-		<VvFormField name="firstname" type="text" label="firstname" showValid />
+		<VvFormField
+			name="firstname"
+			type="text"
+			label="firstname"
+			show-valid
+		/>
 		<VvFormField name="surname" type="text" label="surname" />
-		<VvFormWrapper name="location" v-slot="{ invalid }">
+		<VvFormWrapper v-slot="{ invalid }" name="location">
 			<div class="form-section-1">
-				<small v-if="invalid" class="text-danger"
-					>There is a validation error</small
-				>
+				<small v-if="invalid" class="text-danger">
+					There is a validation error
+				</small>
 				<VvFormField name="location.city" type="text" label="city" />
 				<VvFormField
 					name="location.address"

--- a/test-playwright/VvFormWrapper.vue
+++ b/test-playwright/VvFormWrapper.vue
@@ -41,9 +41,14 @@
 
 <template>
 	<VvForm ref="formEl" v-model="model">
-		<VvFormField name="firstname" type="text" label="firstname" showValid />
+		<VvFormField
+			name="firstname"
+			type="text"
+			label="firstname"
+			show-valid
+		/>
 		<VvFormField name="surname" type="text" label="surname" />
-		<VvFormWrapper name="location" v-slot="{ invalid }">
+		<VvFormWrapper v-slot="{ invalid }" name="location">
 			<div class="form-section-1">
 				<small v-if="invalid" class="text-danger"
 					>There is a validation error</small


### PR DESCRIPTION
feat: `ignoreUpdates()` and `stopUpdatesWatch()` methods are now exposed by `useForm()` and in `VvForm` component default slot scope
BREAKING CHANGE: `VvForm` prop `updateThrottle` is not used anymore, use `updateThrottle` option of `useForm()` instead