### PR TITLE
fix: emit type declarations at dist root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.1.4] - 2026-06-16
+
+### Fixed
+
+- TypeScript declarations are now emitted at the `dist` root (`dist/index.d.ts`) instead of `dist/src/index.d.ts`, so the `types` entry in `package.json` resolves correctly. Consumers no longer get "Could not find a declaration file for module '@volverjs/form-vue'" (regression in `1.1.3`).
+
 ## [1.1.3] - 2026-06-15
 
 ### Added

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "rootDir": "src",
+        "noEmit": false
+    },
+    "include": ["./src/**/*"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -74,6 +74,7 @@ export default () => {
 
             // https://github.com/qmhc/vite-plugin-dts
             dts({
+                tsconfigPath: 'tsconfig.build.json',
                 insertTypesEntry: true,
                 exclude: ['**/test-*/**'],
             }),


### PR DESCRIPTION
The dts plugin emitted declarations to dist/src/index.d.ts because the root tsconfig includes the test directories alongside src, making the computed common root the project root. package.json points types to dist/index.d.ts, so consumers got "Could not find a declaration file".

Add tsconfig.build.json with rootDir set to src and point vite-plugin-dts at it so declarations are emitted at the dist root as expected.